### PR TITLE
Use ci.centos.org as source registry for images in OpenShift deployments

### DIFF
--- a/github/openshift/mattermost-github.app.yaml
+++ b/github/openshift/mattermost-github.app.yaml
@@ -42,7 +42,7 @@ objects:
       spec: 
         containers: 
         - name: mattermost-github-integration
-          image: registry.devshift.net/mattermost/mattermost-github-integration:${IMAGE_TAG}
+          image: registry.centos.org/mattermost/mattermost-github-integration:${IMAGE_TAG}
           imagePullPolicy: Always
           ports:
           - containerPort: 5000

--- a/github/openshift/mattermost-github.app.yaml
+++ b/github/openshift/mattermost-github.app.yaml
@@ -131,3 +131,4 @@ objects:
   status: {}
 parameters:
 - name: IMAGE_TAG
+  value: 92394f2

--- a/gitlab/openshift/mattermost-gitlab.app.yaml
+++ b/gitlab/openshift/mattermost-gitlab.app.yaml
@@ -42,7 +42,7 @@ objects:
       spec:
         containers:
         - name: mattermost-gitlab-integration
-          image: registry.devshift.net/mattermost/mattermost-gitlab-integration:${IMAGE_TAG}
+          image: registry.centos.org/mattermost/mattermost-gitlab-integration:${IMAGE_TAG}
           imagePullPolicy: Always
           ports:
           - containerPort: 5000

--- a/gitlab/openshift/mattermost-gitlab.app.yaml
+++ b/gitlab/openshift/mattermost-gitlab.app.yaml
@@ -121,3 +121,4 @@ objects:
   status: {}
 parameters:
 - name: IMAGE_TAG
+  value: 4a61a48

--- a/irc/openshift/mattermost-irc-bridge.app.yaml
+++ b/irc/openshift/mattermost-irc-bridge.app.yaml
@@ -84,3 +84,4 @@ objects:
     - type: ConfigChange
 parameters:
 - name: IMAGE_TAG
+  value: 1.3.1

--- a/irc/openshift/mattermost-irc-bridge.app.yaml
+++ b/irc/openshift/mattermost-irc-bridge.app.yaml
@@ -41,7 +41,7 @@ objects:
       spec:
         containers:
         - name: mattermost-irc-integration
-          image: registry.devshift.net/mattermost/mattermost-irc-integration:${IMAGE_TAG}
+          image: registry.centos.org/mattermost/mattermost-irc-integration:${IMAGE_TAG}
           imagePullPolicy: Always
           env:
           - name: "IRC_NICK"

--- a/rssfeeds/openshift/mattermost-rss.app.yaml
+++ b/rssfeeds/openshift/mattermost-rss.app.yaml
@@ -71,3 +71,4 @@ objects:
     - type: ConfigChange
 parameters:
 - name: IMAGE_TAG
+  value: 8e189eb

--- a/rssfeeds/openshift/mattermost-rss.app.yaml
+++ b/rssfeeds/openshift/mattermost-rss.app.yaml
@@ -42,7 +42,7 @@ objects:
       spec:
         containers:
         - name: mattermost-rss-integration
-          image: registry.devshift.net/mattermost/mattermost-rss-integration:${IMAGE_TAG}
+          image: registry.centos.org/mattermost/mattermost-rss-integration:${IMAGE_TAG}
           imagePullPolicy: Always
           env:
           - name: "MATTERMOST_HOOK_URL"


### PR DESCRIPTION
Currently the images in the deployments are set up to pull from
registry.devshift.net. Since we are not building the images from source
and using a deploy-only strategy on almighty-jobs, we need to ensure
that the images are pulled from ci.centos.org.