### PR TITLE
Fix Image check script

### DIFF
--- a/gitlab/cico_build_deploy.sh
+++ b/gitlab/cico_build_deploy.sh
@@ -16,7 +16,7 @@ TEMPLATE="openshift/mattermost-gitlab.app.yaml"
 
 #Find tag used by deployment template
 echo -e "Scanning OpenShift Deployment Template for Image tag"
-TAG=$(cat $TEMPLATE | grep -A 1 "name: IMAGE_TAG" | grep "value:" |  awk '{split($0,array,":")} END{print array[2]}')
+TAG=$(cat $TEMPLATE | grep -A 1 "name: IMAGE_TAG_VERSION" | grep "value:" |  awk '{split($0,array,":")} END{print array[2]}')
 
 #Check if image is in the registry
 echo -e "Checking if image exists on the registry"

--- a/gitlab/cico_build_deploy.sh
+++ b/gitlab/cico_build_deploy.sh
@@ -16,7 +16,7 @@ TEMPLATE="openshift/mattermost-gitlab.app.yaml"
 
 #Find tag used by deployment template
 echo -e "Scanning OpenShift Deployment Template for Image tag"
-TAG=$(cat $TEMPLATE | grep -o -e "registry.*" | awk '{split($0,array,"/")} END{print array[3]}' | awk '{split($0,array,":")} END{print array[2]}')
+TAG=$(cat $TEMPLATE | grep -A 1 "name: IMAGE_TAG" | grep "value:" |  awk '{split($0,array,":")} END{print array[2]}')
 
 #Check if image is in the registry
 echo -e "Checking if image exists on the registry"


### PR DESCRIPTION
Earlier implementation looks for image tag in the image URL.
Make the script look for image tag in the parameters section, as the value of IMAGE_TAG