### PR TITLE
Set value for IMAGE_TAG as string

### DIFF
--- a/github/openshift/mattermost-github.app.yaml
+++ b/github/openshift/mattermost-github.app.yaml
@@ -42,7 +42,7 @@ objects:
       spec: 
         containers: 
         - name: mattermost-github-integration
-          image: registry.centos.org/mattermost/mattermost-github-integration:${IMAGE_TAG}
+          image: registry.centos.org/mattermost/mattermost-github-integration:${IMAGE_TAG_VERSION}
           imagePullPolicy: Always
           ports:
           - containerPort: 5000
@@ -130,5 +130,6 @@ objects:
     wildcardPolicy: None
   status: {}
 parameters:
-- name: IMAGE_TAG
+- name: IMAGE_TAG_VERSION
   value: "92394f2"
+- name: IMAGE_TAG

--- a/github/openshift/mattermost-github.app.yaml
+++ b/github/openshift/mattermost-github.app.yaml
@@ -131,4 +131,4 @@ objects:
   status: {}
 parameters:
 - name: IMAGE_TAG
-  value: 92394f2
+  value: "92394f2"

--- a/gitlab/openshift/mattermost-gitlab.app.yaml
+++ b/gitlab/openshift/mattermost-gitlab.app.yaml
@@ -42,7 +42,7 @@ objects:
       spec:
         containers:
         - name: mattermost-gitlab-integration
-          image: registry.centos.org/mattermost/mattermost-gitlab-integration:${IMAGE_TAG}
+          image: registry.centos.org/mattermost/mattermost-gitlab-integration:${IMAGE_TAG_VERSION}
           imagePullPolicy: Always
           ports:
           - containerPort: 5000
@@ -120,5 +120,6 @@ objects:
     wildcardPolicy: None
   status: {}
 parameters:
-- name: IMAGE_TAG
+- name: IMAGE_TAG_VERSION
   value: "4a61a48"
+- name: IMAGE_TAG

--- a/gitlab/openshift/mattermost-gitlab.app.yaml
+++ b/gitlab/openshift/mattermost-gitlab.app.yaml
@@ -121,4 +121,4 @@ objects:
   status: {}
 parameters:
 - name: IMAGE_TAG
-  value: 4a61a48
+  value: "4a61a48"

--- a/irc/openshift/mattermost-irc-bridge.app.yaml
+++ b/irc/openshift/mattermost-irc-bridge.app.yaml
@@ -84,4 +84,4 @@ objects:
     - type: ConfigChange
 parameters:
 - name: IMAGE_TAG
-  value: 1.3.1
+  value: "1.3.1"

--- a/irc/openshift/mattermost-irc-bridge.app.yaml
+++ b/irc/openshift/mattermost-irc-bridge.app.yaml
@@ -41,7 +41,7 @@ objects:
       spec:
         containers:
         - name: mattermost-irc-integration
-          image: registry.centos.org/mattermost/mattermost-irc-integration:${IMAGE_TAG}
+          image: registry.centos.org/mattermost/mattermost-irc-integration:${IMAGE_TAG_VERSION}
           imagePullPolicy: Always
           env:
           - name: "IRC_NICK"
@@ -83,5 +83,6 @@ objects:
   triggers:
     - type: ConfigChange
 parameters:
-- name: IMAGE_TAG
+- name: IMAGE_TAG_VERSION
   value: "1.3.1"
+- name: IMAGE_TAG

--- a/rssfeeds/openshift/mattermost-rss.app.yaml
+++ b/rssfeeds/openshift/mattermost-rss.app.yaml
@@ -42,7 +42,7 @@ objects:
       spec:
         containers:
         - name: mattermost-rss-integration
-          image: registry.centos.org/mattermost/mattermost-rss-integration:${IMAGE_TAG}
+          image: registry.centos.org/mattermost/mattermost-rss-integration:${IMAGE_TAG_VERSION}
           imagePullPolicy: Always
           env:
           - name: "MATTERMOST_HOOK_URL"
@@ -70,5 +70,6 @@ objects:
   triggers:
     - type: ConfigChange
 parameters:
-- name: IMAGE_TAG
+- name: IMAGE_TAG_VERSION
   value: "8e189eb"
+- name: IMAGE_TAG

--- a/rssfeeds/openshift/mattermost-rss.app.yaml
+++ b/rssfeeds/openshift/mattermost-rss.app.yaml
@@ -71,4 +71,4 @@ objects:
     - type: ConfigChange
 parameters:
 - name: IMAGE_TAG
-  value: 8e189eb
+  value: "8e189eb"


### PR DESCRIPTION
Set the value of the IMAGE_TAG parameter as string instead of an int.
Openshift fails to process the file if the value is an int.