### PR TITLE
add variable to mattermost-rss

### DIFF
--- a/rssfeeds/openshift/mattermost-rss.app.yaml
+++ b/rssfeeds/openshift/mattermost-rss.app.yaml
@@ -66,6 +66,8 @@ objects:
               secretKeyRef:
                 name: mattermost-rss-config
                 key: feedurl2
+          - name: RSS_SHOW_DESCR
+            value: 'False'
   test: false
   triggers:
     - type: ConfigChange


### PR DESCRIPTION
this variable is needed so as to skip descriptions of RSS feeds
since it's not finding descriptions for Jenkins jobs, it is failing to fetch feeds.